### PR TITLE
Add Rust development Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: info php ruby node latex
+.PHONY: info php ruby node latex rust
 
 UID := $(shell id -u)
 GID := $(shell id -g)
@@ -22,17 +22,23 @@ NODE_PORT = 3000
 LATEX_NAME = latex-dev-container
 LATEX_VERSION = 1.0
 
-info: # Show available images: 
+# Rust container info
+RUST_NAME = rust-dev-container
+RUST_VERSION = 1.0
+RUST_PORT = 8000
+
+info: # Show available images
 	@echo "Available dev containers:"
 	@echo "- php: PHP 8.2, Laravel 12, Composer"
 	@echo "- ruby: Ruby 3.2, Jekyll"
 	@echo "- node: Node.js 22, npm"
 	@echo "- latex: texlive-latex-extra"
+	@echo "- rust: Rust 1.78, cargo"
 	@echo ""
-	@echo "To run a container"
+	@echo "To run a container:"
 	@echo "docker run -it -p <PORT>:<PORT> -v <MOUNT_DIR>:/workspace <IMAGE>"
 
-php: # Build php dev container
+php: # Build PHP dev container
 	docker build --build-arg USER_UID=$(UID) --build-arg USER_GID=$(GID) -t $(PHP_NAME):$(PHP_VERSION) -f ./php/Dockerfile ./php/
 
 ruby: # Build Ruby dev container
@@ -43,3 +49,6 @@ node: # Build Node.js dev container
 
 latex: # Build LaTeX dev container
 	docker build --build-arg USER_UID=$(UID) --build-arg USER_GID=$(GID) -t $(LATEX_NAME):$(LATEX_VERSION) -f ./latex/Dockerfile ./latex/
+
+rust: # Build Rust dev container
+	docker build --build-arg USER_UID=$(UID) --build-arg USER_GID=$(GID) -t $(RUST_NAME):$(RUST_VERSION) -f ./rust/Dockerfile ./rust/

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,13 @@ General-purpose JavaScript development and web applications.
 - Node.js v22
 - npm
 
+### rust
+Ideal for systems programming, CLI tools, and web backends.
+
+**Included:**
+- rust
+- cargo
+
 ### LaTeX
 A lightweight container for compiling LaTeX documents.
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,0 +1,31 @@
+# Use the official Rust image as the base
+FROM rust:1.78
+
+# Set the working directory inside the container
+WORKDIR /workspace
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    bash \
+    vim \
+    sudo \
+    && apt-get clean
+
+# Expose a typical Rust web dev port (e.g. for actix-web or Rocket)
+EXPOSE 8000
+
+# Add a non-root user with the same UID and GID as the host user (pass via build args)
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+USER $USERNAME
+WORKDIR /workspace
+
+# Default command to keep the container running
+CMD ["bash"]


### PR DESCRIPTION
This PR adds a Rust development Dockerfile to support containerized Rust CLI and web application development.

Included:
- Rust 1.78
- Cargo
- build-essential, Git, Vim, Bash
- Non-root user setup with host UID/GID

Useful for isolated, reproducible Rust environments.
