### PR TITLE
feat: Docker compose + postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Environment file
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 > 
 > This changelog only lists feature additions. See the Git history for more granular changes.
 
-- v1.0
-    - Initial collection of containers
-      - php 
-      - ruby 
-      - node 
-      - latex 
-      - rust
+- 2.0
+    - Added support for `docker-compose` yaml files, and added `.env.example` file for additional configuration.
+    - Introduced `docker-compose-postgres` which builds `postgres` and `pgadmin` containers.
+- 1.0
+    - Initial collection of containers:
+        - php 
+        - ruby 
+        - node 
+        - latex 
+        - rust

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-.PHONY: info php ruby node latex rust
+.PHONY: info
 
 UID := $(shell id -u)
 GID := $(shell id -g)
 
 # Image definitions
 IMAGES := php ruby node latex rust
-VERSION = 1.0
+COMPOSE := postgres
+VERSION = 2.0
 
 info: # Show available images
 	@echo "Available dev containers:"
@@ -14,6 +15,9 @@ info: # Show available images
 	@echo "- node: Node.js 22, npm"
 	@echo "- latex: texlive-latex-extra"
 	@echo "- rust: Rust 1.78, cargo"
+	@echo ""
+	@echo "Available docker compose recipes:"
+	@echo "- postgres: postgres:16, pgadmin:4.8"
 	@echo ""
 	@echo "To run a container:"
 	@echo "docker run -it -p <PORT>:<PORT> -v <MOUNT_DIR>:/workspace <IMAGE>"
@@ -25,3 +29,9 @@ $(IMAGES):
 		--build-arg USER_GID=$(GID) \
 		-t $@-dev-container:$(VERSION) \
 		-f dockerfiles/Dockerfile.$@ .
+
+# Rules for docker-compose
+$(COMPOSE):
+	docker compose \
+		-f docker-compose/docker-compose-$@.yaml \
+		up -d

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 `dev-containers` offers a collection Dockerfiles for various language-specific development environments. The goal is to offer **reproducible, disposable containers** that eliminate the need to install a billion toolchains and dependencies directly on your system. Especially useful for temporary or isolated projects like [Advent of Code](https://adventofcode.com/).
 
+## Prerequisites
+
+Install docker and docker compose. For Debian-based systems, you can use the following command:
+```sh
+sudo apt install docker.io docker-compose
+```
+
 ## Containers
 
 All containers are Linux-based. Each container installs the following packages:
@@ -58,7 +65,7 @@ Provides most required tools and packages for compiling LaTeX documents.
 - `luatex`
 - `texlive-fonts`
 
-## Building & Running
+### Building containers
 
 Use the included `Makefile` to build container images easily:
 ```sh
@@ -86,6 +93,38 @@ docker run -it -p 4000:4000 -v ~/projects/my-app:/workspace php-dev-container:1.
   - When building without specifying the UID and GID, the files created inside the container will be owned by root -- this will likely cause permission issues on the host (e.g. in VSCode or Git).
   - You can manually fix the permission issues by running `chown $USER [file]`.
 
+## Docker compose
+
+As of tag `2.0`, this repository also provides `docker-compose` configuration files. Docker compose files are designed to be used for creating multiple related containers (e.g. database + admin panel), and might require additional environment configuration (e.g. default username + password).
+
+As opposed to the docker containers above, compose recipes are designed to be less "general-purpose". This means that, at the moment, additional base software (like vim or git) is not added to the containers.
+
+### Postgres
+Defined in the `docker-compose-postgres.yaml`, this compose configuration will build images for 2 containers:
+- **postgres:16**: Object-relational database system.
+- **pgadmin:4.8**: Web-based database administration system.
+
+The environment configuration for those containers can be found in the `.env.example` file.
+
+### Building
+
+First step should be to make an `.env` file from the example provided:
+```sh
+cp docker-compose/.env.example docker-compose/.env
+```
+
+You can build the specified container with the following command:
+```sh
+docker compose -f {path/to/compose.yaml} up -d
+```
+
+This will run the containers and detach them.
+
+Alternatively use `make`:
+```sh
+make postgres
+```
+
 ## Future
 - **PHP Container**:
   - Add `node` and `npm` to support JS tooling (e.g. Laravel Mix, Vite).
@@ -97,5 +136,3 @@ docker run -it -p 4000:4000 -v ~/projects/my-app:/workspace php-dev-container:1.
   - `.devcontainer` configuration.
   - Recommended extensions.
   - Volume mounts for workspaces.
-
-  

--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -1,0 +1,10 @@
+# ===== docker-compose-postgres =====
+
+# postgres container
+POSTGRES_USER=username
+POSTGRES_PASSWORD=password
+POSTGRES_DB=default_database
+
+# pgadmin container
+PGADMIN_DEFAULT_EMAIL=admin@email.com
+PGADMIN_DEFAULT_PASSWORD=admin123

--- a/docker-compose/docker-compose-postgres.yaml
+++ b/docker-compose/docker-compose-postgres.yaml
@@ -16,7 +16,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U allergyfrog"]
+      test: pg_isready -U ${POSTGRES_USER}
       interval: 5s
       timeout: 3s
       retries: 5
@@ -36,3 +36,4 @@ services:
 
 volumes:
   postgres_data:
+

--- a/docker-compose/docker-compose-postgres.yaml
+++ b/docker-compose/docker-compose-postgres.yaml
@@ -1,0 +1,38 @@
+# docker-compose-postgres.yaml
+
+version: '1.0'
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U allergyfrog"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  pgadmin:
+    image: dpage/pgadmin4:8
+    container_name: pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+    ports:
+      - "8080:80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Version 2.0
- Added support for `docker-compose` recipes, along with `.env` file for additional environment configuration. 
- `.env.example` exists as a base
- Added postgres `docker-compose` recipe which includes:
  - postgres
  - pgadmin
- Updated readme and Makefile
- Added `.gitignore`